### PR TITLE
Update dependencies to run on modern Expo

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
   "presets": [
-    "babel-preset-exponent"
+    "babel-preset-expo"
   ]
 }

--- a/exp.json
+++ b/exp.json
@@ -2,13 +2,13 @@
   "name": "react-native-card-modal",
   "description": "A pure javascript card modal for React Native framework. https://github.com/ggomaeng/react-native-card-modal",
   "slug": "react-native-card-modal",
-  "sdkVersion": "11.0.0",
+  "sdkVersion": "21.0.0",
   "version": "1.0.0",
   "orientation": "portrait",
   "primaryColor": "#e92d49",
-  "iconUrl": "https://s3.amazonaws.com/exp-us-standard/icons/card-modal-icon.png",
+  "icon": "https://s3.amazonaws.com/exp-us-standard/icons/card-modal-icon.png",
   "loading": {
-    "iconUrl": "https://s3.amazonaws.com/exp-us-standard/icons/card-modal-icon.png",
+    "icon": "https://s3.amazonaws.com/exp-us-standard/icons/card-modal-icon.png",
     "hideExponentText": false
   },
   "packagerOpts": {

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import Exponent from 'exponent';
+import Expo from 'expo';
 import Main from './src/main';
 
-Exponent.registerRootComponent(Main);
+Expo.registerRootComponent(Main);

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
     "test": "jest"
   },
   "dependencies": {
-    "@exponent/vector-icons": "~2.0.0",
-    "exponent": "~11.0.2",
-    "react": "~15.3.2",
-    "react-native": "github:exponentjs/react-native#sdk-11.0.3",
+    "@expo/vector-icons": "~6.3.1",
+    "babel-preset-expo": "^4.0.0",
+    "expo": "^21.0.0",
+    "react": "16.0.0-alpha.12",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-21.0.2.tar.gz",
     "react-native-animatable": "^0.6.1",
     "react-native-navbar": "^1.5.4",
     "react-native-vector-icons": "^3.0.0"

--- a/src/components/card-modal.js
+++ b/src/components/card-modal.js
@@ -262,8 +262,8 @@ export default class CardModal extends Component {
     renderTop() {
         var back = this.state.pressed
             ?
-            <TouchableOpacity style={[styles.backButton, {opacity: this.state.back_opac}]} onPress={this._onPress}>
-                <Animated.View >
+            <TouchableOpacity style={[styles.backButton]} onPress={this._onPress}>
+                <Animated.View style={{opacity: this.state.back_opac}}>
                     <Text style={{color: 'white'}}><Icon name='chevron-left' /></Text>
                 </Animated.View>
             </TouchableOpacity>


### PR DESCRIPTION
Updating this demo to Expo SDK v21 and renaming Exponent to Expo throughout gets `exp start` to work as of April 2018. Might even be able to use the most recent SDK, but this is enough porting work for now.

At that point the images would not render due to an error in the View component with a strange non-numerical opacity value. It's possible this was benign with SDK v11 but now needs to be fixed by moving the value into `Animated.View` like the other three opacity states.

- [ ] Fixes #11